### PR TITLE
Add missing "for" attributes on password field labels

### DIFF
--- a/lib/demo_web/templates/user_settings/edit.html.eex
+++ b/lib/demo_web/templates/user_settings/edit.html.eex
@@ -13,7 +13,7 @@
   <%= text_input f, :email, required: true %>
   <%= error_tag f, :email %>
 
-  <%= label f, :current_password %>
+  <%= label f, :current_password, for: "current_password_for_email" %>
   <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_email" %>
   <%= error_tag f, :current_password %>
 
@@ -39,7 +39,7 @@
   <%= password_input f, :password_confirmation, required: true %>
   <%= error_tag f, :password_confirmation %>
 
-  <%= label f, :current_password %>
+  <%= label f, :current_password, for: "current_password_for_password" %>
   <%= password_input f, :current_password, required: true, name: "current_password", id: "current_password_for_password" %>
   <%= error_tag f, :current_password %>
 


### PR DESCRIPTION
Because the id of the password fields have been changed, the labels need their "for" attributes to match them.