### PR TITLE
Only hash password when saving to database

### DIFF
--- a/lib/demo/accounts/user.ex
+++ b/lib/demo/accounts/user.ex
@@ -43,13 +43,11 @@ defmodule Demo.Accounts.User do
     # |> validate_format(:password, ~r/[a-z]/, message: "at least one lower case character")
     # |> validate_format(:password, ~r/[A-Z]/, message: "at least one upper case character")
     # |> validate_format(:password, ~r/[!?@#$%^&*_0-9]/, message: "at least one digit or punctuation character")
-    |> maybe_hash_password()
+    |> prepare_changes(&maybe_hash_password/1)
   end
 
   defp maybe_hash_password(changeset) do
-    password = get_change(changeset, :password)
-
-    if password && changeset.valid? do
+    if password = get_change(changeset, :password) do
       changeset
       |> put_change(:hashed_password, Bcrypt.hash_pwd_salt(password))
       |> delete_change(:password)


### PR DESCRIPTION
Currently, when `validate_password/1` runs, it hashes the password each time. If a user runs `registration_changeset/1` in a LiveView with live validations, the hashing code create unnecessary load on the server. This ensures the password is only hashed right before it's saved to the database.