### PR TITLE
changed verb from delete to get in order to logout

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "workbench.colorCustomizations": {
+    "activityBar.background": "#113511",
+    "titleBar.activeBackground": "#184A17",
+    "titleBar.activeForeground": "#F5FCF5"
+  }
+}

--- a/lib/demo_web/router.ex
+++ b/lib/demo_web/router.ex
@@ -54,7 +54,7 @@ defmodule DemoWeb.Router do
   scope "/", DemoWeb do
     pipe_through [:browser]
 
-    delete "/users/logout", UserSessionController, :delete
+    get "/users/logout", UserSessionController, :delete
     get "/users/confirm", UserConfirmationController, :new
     post "/users/confirm", UserConfirmationController, :create
     get "/users/confirm/:token", UserConfirmationController, :confirm


### PR DESCRIPTION
I am fairly certain that this isn't the fix for the issue, but logout doesn't work because it is trying to do a GET instead of a DELETE:

Phoenix.Router.NoRouteError at GET /users/logout
no route found for GET /users/logout (DemoWeb.Router)

I am not well versed enough to know why it would be calling for GET when the user menu seems to be requesting the :delete method:
  <li><%= link "Logout", to: Routes.user_session_path(@conn, :delete), method: :delete %></li>

<br>
But changing "delete" to "get" let's me logout and I wanted to let you all know about it. Thanks for all the work you're doing! Elixir is teh awesome sauce! 